### PR TITLE
chore: remove stale main field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/yanoshi-1009/kintone-customization-template"
   },
   "type": "module",
-  "main": "index.ts",
   "engines": {
     "node": ">=26.0.0"
   },


### PR DESCRIPTION
## Summary
- Removed the `"main": "index.ts"` field from `package.json` — it pointed at a root `index.ts` that has never existed in this repo (verified via `git ls-files`); esbuild uses explicit `entryPoints` in `scripts/esbuild/build.ts` instead, so this was dead config.
- No other dead code was removed: the remaining "unreferenced" items found during analysis (i18n `t`/`i18n` exports, empty `config.ts`/`fields.d.ts`, unused `chart.js`/`kintone-ui-component`/`@kintone/rest-api-client` deps) are intentional template scaffolding documented in README.md.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm exec prettier --check package.json` passes
- [x] `pnpm run build:prod` succeeds and produces `dist/index.js`, `dist/mobile.js`, `dist/styles/style.css`, `dist/styles/mobile.css`